### PR TITLE
ipv6 hosts list entries cause libvirt dnsmasq to error out

### DIFF
--- a/modules/machines/common/network/adblock.nix
+++ b/modules/machines/common/network/adblock.nix
@@ -1,15 +1,13 @@
-{ inputs, ... }:
+{ inputs, lib, ... }:
 
+let
+  combined = builtins.readFile (inputs.hosts.outPath + "/alternates/fakenews-gambling-porn/hosts");
+
+  cleaned = lib.concatStringsSep "\n" (
+    lib.filter (line: !(lib.hasInfix "::" line)) (lib.splitString "\n" combined)
+  );
+
+in
 {
-  imports = [ inputs.hosts.nixosModule ];
-
-  # use Steven Black's hostlists
-  # to block bad content
-  networking.stevenBlackHosts = {
-    enable = true;
-    blockFakenews = true;
-    blockGambling = true;
-    blockPorn = true;
-    blockSocial = false;
-  };
+  networking.extraHosts = cleaned;
 }


### PR DESCRIPTION
```
--- /tmp/hosts.old	2026-04-07 13:07:38.479067790 +0530
+++ /etc/hosts	1970-01-01 05:30:01.000000000 +0530
@@ -20,15 +20,6 @@
 127.0.0.1 localhost.localdomain
 127.0.0.1 local
 255.255.255.255 broadcasthost
-::1 localhost
-::1 ip6-localhost
-::1 ip6-loopback
-fe80::1%lo0 localhost
-ff00::0 ip6-localnet
-ff00::0 ip6-mcastprefix
-ff02::1 ip6-allnodes
-ff02::2 ip6-allrouters
-ff02::3 ip6-allhosts
 0.0.0.0 0.0.0.0
 
 # Custom host records are listed here.
@@ -84672,7 +84663,6 @@
 # your information back to a company.
 
 #<localhost>
-#fe80::1%lo0	localhost
 #</localhost>
 
 #<shortcut-examples>
```