### PR TITLE
use rpool/nixos/var on laptop

### DIFF
--- a/cli/scripts/bootstrap
+++ b/cli/scripts/bootstrap
@@ -150,20 +150,23 @@ if [ "$VERB" == "disks" ]; then
         run sudo zfs create rpool/nixos
         run sudo zfs create rpool/nixos/root -o mountpoint=legacy
         run sudo zfs create rpool/nixos/home -o mountpoint=legacy
+        run sudo zfs create rpool/nixos/var -o mountpoint=legacy
         run sudo zfs create rpool/nixos/nix -o mountpoint=legacy
         run sudo zfs create rpool/nixos/persist -o mountpoint=legacy
 
         # 8) empty snapshots for impermanence
         run sudo zfs snapshot rpool/nixos/root@blank
         run sudo zfs snapshot rpool/nixos/home@blank
+        run sudo zfs snapshot rpool/nixos/var@blank
 
     elif [ "$ARG1" == "mount" ]; then
 
         # 10) mount filesystems
         run sudo mkdir -p /mnt
         run sudo mount -t zfs rpool/nixos/root /mnt
-        run sudo mkdir -p /mnt/home /mnt/nix /mnt/persist
+        run sudo mkdir -p /mnt/home /mnt/var /mnt/nix /mnt/persist
         run sudo mount -t zfs rpool/nixos/home /mnt/home
+        run sudo mount -t zfs rpool/nixos/var /mnt/var
         run sudo mount -t zfs rpool/nixos/nix /mnt/nix
         run sudo mount -t zfs rpool/nixos/persist /mnt/persist
 

--- a/doc/filesystems.md
+++ b/doc/filesystems.md
@@ -35,10 +35,11 @@ Three partitions are used:
 The bootstrap script creates four datasets:
 
 ```
-rpool/nixos/nix        mounted at /nix
-rpool/nixos/persist    mounted at /persist
 rpool/nixos/root       mounted at /
 rpool/nixos/home       mounted at /home
+rpool/nixos/var        mounted at /var
+rpool/nixos/nix        mounted at /nix
+rpool/nixos/persist    mounted at /persist
 ```
 
 Two blank snapshots are also created at this time:
@@ -46,6 +47,7 @@ Two blank snapshots are also created at this time:
 ```
 rpool/nixos/root@blank
 rpool/nixos/home@blank
+rpool/nixos/var@blank
 ```
 
 The blank snapshots are relevant for Impermanence.
@@ -93,6 +95,7 @@ On the Laptop role, the following directories are hardened without Impermanence:
 | `/root`             | Data    |
 | `/srv`              | Data    |
 | `/tmp`              | Data    |
+| `/var`              | Data    |
 
 On the Server role, the following directories are hardened without Impermanence:
 
@@ -102,8 +105,11 @@ On the Server role, the following directories are hardened without Impermanence:
 | `/persist/sops-nix` | Data    |
 | `/tmp`              | Data    |
 
-Additionally, directories persisted using Impermanence are also hardened
-separately.
+Note that Impermanence is required to harden various other directories on
+Server.
+
+Additionally, directories persisted using Impermanence on Laptop and Server are
+also hardened.
 
 # Additional Disks and Mounts
 
@@ -287,19 +293,19 @@ snapshots:
 ```
 rpool/nixos/root@blank
 rpool/nixos/home@blank
+rpool/nixos/var@blank
 ```
 
 During the Impermanence setup (post-install), the bootstrap script populates
 `/persist/root` with the default directories to persist.
 
-During early boot, systemd services roll back the `rpool/nixos/root` and
-`rpool/nixos/home` datasets.
+During early boot, systemd services roll back the `rpool/nixos/root`,
+`rpool/nixos/home` and `rpool/nixos/var` datasets.
 
-So, in early boot, the `rpool/nixos/root` and `rpool/nixos/home` directories are
-**completely empty**. Nix populates it with relevant files from `/nix` based on
-the system closure.
-
-All directories are persisted using bind mounts from `/persist/root`.
+So, in early boot, the `/`, `/home` and `/var` directories are **completely
+empty**. Nix populates it with relevant files from `/nix` based on the system
+closure. All other directories are persisted using bind mounts from
+`/persist/root`.
 
 ### Persisted Directories
 
@@ -345,6 +351,7 @@ At any given point, to see the files that will be thrown out by Impermanence:
 ```console
 # zfs diff rpool/root@blank
 # zfs diff rpool/home@blank
+# zfs diff rpool/var@blank
 ```
 
 ### Adding Directories
@@ -393,7 +400,6 @@ The following directories are persisted by default:
 
 | Path                    | Description              | Profile |
 | ----------------------- | ------------------------ | ------- |
-| `/var/lib/sbctl`        | secure boot keys         | Data    |
 | `/var/lib/nixos`        | needed by nixos          | Data    |
 | `/var/lib/systemd`      | needed by systemd        | Data    |
 | `/etc/zfs`              | needed by ZFS            | Data    |

--- a/doc/laptop/setup.md
+++ b/doc/laptop/setup.md
@@ -150,6 +150,7 @@ Before proceeding, see [Laptop Requirements](./requirements.md).
    sudo zfs create rpool/nixos
    sudo zfs create rpool/nixos/root -o mountpoint=legacy
    sudo zfs create rpool/nixos/home -o mountpoint=legacy
+   sudo zfs create rpool/nixos/var -o mountpoint=legacy
    sudo zfs create rpool/nixos/nix -o mountpoint=legacy
    sudo zfs create rpool/nixos/persist -o mountpoint=legacy
    ```
@@ -160,6 +161,7 @@ Before proceeding, see [Laptop Requirements](./requirements.md).
    ```bash
    sudo zfs snapshot rpool/nixos/root@blank
    sudo zfs snapshot rpool/nixos/home@blank
+   sudo zfs snapshot rpool/nixos/var@blank
    ```
 
 9. Mount ZFS datasets.
@@ -167,6 +169,7 @@ Before proceeding, see [Laptop Requirements](./requirements.md).
    ```bash
    sudo mkdir -p /mnt && sudo mount rpool/nixos/root /mnt -t zfs
    sudo mkdir -p /mnt/home && sudo mount rpool/nixos/home /mnt/home -t zfs
+   sudo mkdir -p /mnt/var && sudo mount rpool/nixos/var /mnt/var -t zfs
    sudo mkdir -p /mnt/nix && sudo mount rpool/nixos/nix /mnt/nix -t zfs
    sudo mkdir -p /mnt/persist && sudo mount rpool/nixos/persist /mnt/persist -t zfs
    ```

--- a/roles/machine-laptop/configuration.nix
+++ b/roles/machine-laptop/configuration.nix
@@ -85,6 +85,14 @@
       options = lib.mountData;
     };
 
+    # rpool/nixos/var -> /var
+    # nosuid,nodev,noexec
+    "/var" = {
+      device = "rpool/nixos/var";
+      fsType = "zfs";
+      options = lib.mountData;
+    };
+
     # rpool/nixos/nix -> /nix
     "/nix" = {
       device = "rpool/nixos/nix";

--- a/roles/machine-laptop/impermanence/bind-root.nix
+++ b/roles/machine-laptop/impermanence/bind-root.nix
@@ -7,29 +7,11 @@ lib.mkIf config.vars.features.impermanence.enable {
     # nosuid, nodev, noexec
     lib.mkPersistData "/persist/root" [
 
-      # needed by nixos
-      "/var/lib/nixos"
-
-      # needed by systemd
-      "/var/lib/systemd"
-
       # needed by ZFS
       "/etc/zfs"
 
       # ssh host keys
       "/etc/ssh"
-
-      # fail2ban data
-      "/var/lib/fail2ban"
-
-      # secure boot
-      "/var/lib/sbctl"
-
-      # libvirt virtual machines
-      "/var/lib/libvirt"
-
-      # logs
-      "/var/log"
 
     ];
 

--- a/roles/machine-laptop/impermanence/bind-var.nix
+++ b/roles/machine-laptop/impermanence/bind-var.nix
@@ -1,0 +1,30 @@
+{ config, lib, ... }:
+
+lib.mkIf config.vars.features.impermanence.enable {
+
+  fileSystems =
+
+    # nosuid, nodev, noexec
+    lib.mkPersistData "/persist/root" [
+
+      # needed by nixos
+      "/var/lib/nixos"
+
+      # needed by systemd
+      "/var/lib/systemd"
+
+      # fail2ban data
+      "/var/lib/fail2ban"
+
+      # secure boot
+      "/var/lib/sbctl"
+
+      # libvirt virtual machines
+      "/var/lib/libvirt"
+
+      # logs
+      "/var/log"
+
+    ];
+
+}

--- a/roles/machine-laptop/impermanence/default.nix
+++ b/roles/machine-laptop/impermanence/default.nix
@@ -2,7 +2,9 @@
   imports = [
     ./bind-home.nix
     ./bind-root.nix
+    ./bind-var.nix
     ./rollback-home.nix
     ./rollback-root.nix
+    ./rollback-var.nix
   ];
 }

--- a/roles/machine-laptop/impermanence/rollback-var.nix
+++ b/roles/machine-laptop/impermanence/rollback-var.nix
@@ -1,0 +1,26 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+
+{
+  config = lib.mkIf config.vars.features.impermanence.enable {
+
+    # Rollback /
+    boot.initrd.systemd.services.rollback-var = {
+      description = "Rollback /var";
+      wantedBy = [ "initrd.target" ];
+      after = [ "zfs-import-rpool.service" ];
+      before = [ "sysroot.mount" ];
+      path = [ pkgs.zfs ];
+      unitConfig.DefaultDependencies = "no";
+      serviceConfig.Type = "oneshot";
+      script = ''
+        zfs rollback -r rpool/nixos/var@blank
+      '';
+    };
+
+  };
+}


### PR DESCRIPTION
- ensures `Data` on `/var` without issues like https://github.com/sotormd/nixos/commit/b472206b11ed9c5f76d10e9cb1d46bad0779bb7b
- better separation instead of having everything under `rpool/root` and `rpool/home`